### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ unused `React` should be ignored, but that's not always true.
 With this module you'll no longer need to use this anti-pattern:
 
 ```jsx
-let React = require('react'); // free, seemingly unused
+const React = require('react'); // free, seemingly unused
 
 module.exports = function MyComponent () {
   return (


### PR DESCRIPTION
Don't use `let`. Instead use `const` if not an import.
People often don't know whe to use `const` vs. `let`. Wrong examples don't help the cause. Either use `import` or `const` since `let`  can simply be reassigned and should not be used as in the example.

Event though it's only an example, this should be done properly.